### PR TITLE
Update testgen to require the latest codegen

### DIFF
--- a/testgen/requirements.txt
+++ b/testgen/requirements.txt
@@ -1,3 +1,3 @@
 icontract>=2.6.1,<3
 aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@e3707bf#egg=aas-core-meta
-aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@46ddb38f#egg=aas-core-codegen
+aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@5a5be978#egg=aas-core-codegen


### PR DESCRIPTION
We update the requirements in testgen to require the latest [aas-core-codegen 5a5be978], which was actually used to generate the test code.

We do not run testgen in CI as it changes so rarely. However, we missed to notice the outdated requirements in this one case.

[aas-core-codegen 5a5be978]: https://github.com/aas-core-works/aas-core-codegen/commit/5a5be978