### PR TITLE
Verify constrained primitives in non-recursion

### DIFF
--- a/src/verification.ts
+++ b/src/verification.ts
@@ -2182,6 +2182,18 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       yield new VerificationError("The value must match the value type.");
     }
 
+    for (const error of verifyNonEmptyString(that.name)) {
+      error.path.prepend(new PropertySegment(that, "name"));
+      yield error;
+    }
+
+    if (that.value !== null) {
+      for (const error of verifyValueDataType(that.value)) {
+        error.path.prepend(new PropertySegment(that, "value"));
+        yield error;
+      }
+    }
+
     if (context === true) {
       if (that.semanticId !== null) {
         for (const error of this.transformWithContext(that.semanticId, context)) {
@@ -2204,18 +2216,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           supplementalSemanticIdsIndex++;
-        }
-      }
-
-      for (const error of verifyNonEmptyString(that.name)) {
-        error.path.prepend(new PropertySegment(that, "name"));
-        yield error;
-      }
-
-      if (that.value !== null) {
-        for (const error of verifyValueDataType(that.value)) {
-          error.path.prepend(new PropertySegment(that, "value"));
-          yield error;
         }
       }
 
@@ -2253,6 +2253,20 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    if (that.version !== null) {
+      for (const error of verifyNonEmptyString(that.version)) {
+        error.path.prepend(new PropertySegment(that, "version"));
+        yield error;
+      }
+    }
+
+    if (that.revision !== null) {
+      for (const error of verifyNonEmptyString(that.revision)) {
+        error.path.prepend(new PropertySegment(that, "revision"));
+        yield error;
+      }
+    }
+
     if (context === true) {
       if (that.embeddedDataSpecifications !== null) {
         let embeddedDataSpecificationsIndex = 0;
@@ -2268,20 +2282,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           embeddedDataSpecificationsIndex++;
-        }
-      }
-
-      if (that.version !== null) {
-        for (const error of verifyNonEmptyString(that.version)) {
-          error.path.prepend(new PropertySegment(that, "version"));
-          yield error;
-        }
-      }
-
-      if (that.revision !== null) {
-        for (const error of verifyNonEmptyString(that.revision)) {
-          error.path.prepend(new PropertySegment(that, "revision"));
-          yield error;
         }
       }
     }
@@ -2321,6 +2321,18 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    for (const error of verifyQualifierType(that.type)) {
+      error.path.prepend(new PropertySegment(that, "type"));
+      yield error;
+    }
+
+    if (that.value !== null) {
+      for (const error of verifyValueDataType(that.value)) {
+        error.path.prepend(new PropertySegment(that, "value"));
+        yield error;
+      }
+    }
+
     if (context === true) {
       if (that.semanticId !== null) {
         for (const error of this.transformWithContext(that.semanticId, context)) {
@@ -2343,18 +2355,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           supplementalSemanticIdsIndex++;
-        }
-      }
-
-      for (const error of verifyQualifierType(that.type)) {
-        error.path.prepend(new PropertySegment(that, "type"));
-        yield error;
-      }
-
-      if (that.value !== null) {
-        for (const error of verifyValueDataType(that.value)) {
-          error.path.prepend(new PropertySegment(that, "value"));
-          yield error;
         }
       }
 
@@ -2456,6 +2456,32 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    if (that.category !== null) {
+      for (const error of verifyNonEmptyString(that.category)) {
+        error.path.prepend(new PropertySegment(that, "category"));
+        yield error;
+      }
+    }
+
+    if (that.idShort !== null) {
+      for (const error of verifyIdShort(that.idShort)) {
+        error.path.prepend(new PropertySegment(that, "idShort"));
+        yield error;
+      }
+    }
+
+    if (that.checksum !== null) {
+      for (const error of verifyNonEmptyString(that.checksum)) {
+        error.path.prepend(new PropertySegment(that, "checksum"));
+        yield error;
+      }
+    }
+
+    for (const error of verifyIdentifier(that.id)) {
+      error.path.prepend(new PropertySegment(that, "id"));
+      yield error;
+    }
+
     if (context === true) {
       if (that.extensions !== null) {
         let extensionsIndex = 0;
@@ -2466,20 +2492,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           extensionsIndex++;
-        }
-      }
-
-      if (that.category !== null) {
-        for (const error of verifyNonEmptyString(that.category)) {
-          error.path.prepend(new PropertySegment(that, "category"));
-          yield error;
-        }
-      }
-
-      if (that.idShort !== null) {
-        for (const error of verifyIdShort(that.idShort)) {
-          error.path.prepend(new PropertySegment(that, "idShort"));
-          yield error;
         }
       }
 
@@ -2507,23 +2519,11 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
         }
       }
 
-      if (that.checksum !== null) {
-        for (const error of verifyNonEmptyString(that.checksum)) {
-          error.path.prepend(new PropertySegment(that, "checksum"));
-          yield error;
-        }
-      }
-
       if (that.administration !== null) {
         for (const error of this.transformWithContext(that.administration, context)) {
           error.path.prepend(new PropertySegment(that, "administration"));
           yield error;
         }
-      }
-
-      for (const error of verifyIdentifier(that.id)) {
-        error.path.prepend(new PropertySegment(that, "id"));
-        yield error;
       }
 
       if (that.embeddedDataSpecifications !== null) {
@@ -2612,19 +2612,18 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
 
   *transformResourceWithContext(
     that: AasTypes.Resource,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     context: boolean
   ): IterableIterator<VerificationError> {
-    if (context === true) {
-      for (const error of verifyPathType(that.path)) {
-        error.path.prepend(new PropertySegment(that, "path"));
-        yield error;
-      }
+    for (const error of verifyPathType(that.path)) {
+      error.path.prepend(new PropertySegment(that, "path"));
+      yield error;
+    }
 
-      if (that.contentType !== null) {
-        for (const error of verifyContentType(that.contentType)) {
-          error.path.prepend(new PropertySegment(that, "contentType"));
-          yield error;
-        }
+    if (that.contentType !== null) {
+      for (const error of verifyContentType(that.contentType)) {
+        error.path.prepend(new PropertySegment(that, "contentType"));
+        yield error;
       }
     }
   }
@@ -2652,6 +2651,16 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    for (const error of verifyNonEmptyString(that.name)) {
+      error.path.prepend(new PropertySegment(that, "name"));
+      yield error;
+    }
+
+    for (const error of verifyNonEmptyString(that.value)) {
+      error.path.prepend(new PropertySegment(that, "value"));
+      yield error;
+    }
+
     if (context === true) {
       if (that.semanticId !== null) {
         for (const error of this.transformWithContext(that.semanticId, context)) {
@@ -2675,16 +2684,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
           }
           supplementalSemanticIdsIndex++;
         }
-      }
-
-      for (const error of verifyNonEmptyString(that.name)) {
-        error.path.prepend(new PropertySegment(that, "name"));
-        yield error;
-      }
-
-      for (const error of verifyNonEmptyString(that.value)) {
-        error.path.prepend(new PropertySegment(that, "value"));
-        yield error;
       }
 
       for (const error of this.transformWithContext(that.externalSubjectId, context)) {
@@ -2831,6 +2830,32 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    if (that.category !== null) {
+      for (const error of verifyNonEmptyString(that.category)) {
+        error.path.prepend(new PropertySegment(that, "category"));
+        yield error;
+      }
+    }
+
+    if (that.idShort !== null) {
+      for (const error of verifyIdShort(that.idShort)) {
+        error.path.prepend(new PropertySegment(that, "idShort"));
+        yield error;
+      }
+    }
+
+    if (that.checksum !== null) {
+      for (const error of verifyNonEmptyString(that.checksum)) {
+        error.path.prepend(new PropertySegment(that, "checksum"));
+        yield error;
+      }
+    }
+
+    for (const error of verifyIdentifier(that.id)) {
+      error.path.prepend(new PropertySegment(that, "id"));
+      yield error;
+    }
+
     if (context === true) {
       if (that.extensions !== null) {
         let extensionsIndex = 0;
@@ -2841,20 +2866,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           extensionsIndex++;
-        }
-      }
-
-      if (that.category !== null) {
-        for (const error of verifyNonEmptyString(that.category)) {
-          error.path.prepend(new PropertySegment(that, "category"));
-          yield error;
-        }
-      }
-
-      if (that.idShort !== null) {
-        for (const error of verifyIdShort(that.idShort)) {
-          error.path.prepend(new PropertySegment(that, "idShort"));
-          yield error;
         }
       }
 
@@ -2882,23 +2893,11 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
         }
       }
 
-      if (that.checksum !== null) {
-        for (const error of verifyNonEmptyString(that.checksum)) {
-          error.path.prepend(new PropertySegment(that, "checksum"));
-          yield error;
-        }
-      }
-
       if (that.administration !== null) {
         for (const error of this.transformWithContext(that.administration, context)) {
           error.path.prepend(new PropertySegment(that, "administration"));
           yield error;
         }
-      }
-
-      for (const error of verifyIdentifier(that.id)) {
-        error.path.prepend(new PropertySegment(that, "id"));
-        yield error;
       }
 
       if (that.semanticId !== null) {
@@ -3079,6 +3078,27 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    if (that.category !== null) {
+      for (const error of verifyNonEmptyString(that.category)) {
+        error.path.prepend(new PropertySegment(that, "category"));
+        yield error;
+      }
+    }
+
+    if (that.idShort !== null) {
+      for (const error of verifyIdShort(that.idShort)) {
+        error.path.prepend(new PropertySegment(that, "idShort"));
+        yield error;
+      }
+    }
+
+    if (that.checksum !== null) {
+      for (const error of verifyNonEmptyString(that.checksum)) {
+        error.path.prepend(new PropertySegment(that, "checksum"));
+        yield error;
+      }
+    }
+
     if (context === true) {
       if (that.extensions !== null) {
         let extensionsIndex = 0;
@@ -3089,20 +3109,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           extensionsIndex++;
-        }
-      }
-
-      if (that.category !== null) {
-        for (const error of verifyNonEmptyString(that.category)) {
-          error.path.prepend(new PropertySegment(that, "category"));
-          yield error;
-        }
-      }
-
-      if (that.idShort !== null) {
-        for (const error of verifyIdShort(that.idShort)) {
-          error.path.prepend(new PropertySegment(that, "idShort"));
-          yield error;
         }
       }
 
@@ -3127,13 +3133,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           descriptionIndex++;
-        }
-      }
-
-      if (that.checksum !== null) {
-        for (const error of verifyNonEmptyString(that.checksum)) {
-          error.path.prepend(new PropertySegment(that, "checksum"));
-          yield error;
         }
       }
 
@@ -3396,6 +3395,27 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    if (that.category !== null) {
+      for (const error of verifyNonEmptyString(that.category)) {
+        error.path.prepend(new PropertySegment(that, "category"));
+        yield error;
+      }
+    }
+
+    if (that.idShort !== null) {
+      for (const error of verifyIdShort(that.idShort)) {
+        error.path.prepend(new PropertySegment(that, "idShort"));
+        yield error;
+      }
+    }
+
+    if (that.checksum !== null) {
+      for (const error of verifyNonEmptyString(that.checksum)) {
+        error.path.prepend(new PropertySegment(that, "checksum"));
+        yield error;
+      }
+    }
+
     if (context === true) {
       if (that.extensions !== null) {
         let extensionsIndex = 0;
@@ -3406,20 +3426,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           extensionsIndex++;
-        }
-      }
-
-      if (that.category !== null) {
-        for (const error of verifyNonEmptyString(that.category)) {
-          error.path.prepend(new PropertySegment(that, "category"));
-          yield error;
-        }
-      }
-
-      if (that.idShort !== null) {
-        for (const error of verifyIdShort(that.idShort)) {
-          error.path.prepend(new PropertySegment(that, "idShort"));
-          yield error;
         }
       }
 
@@ -3444,13 +3450,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           descriptionIndex++;
-        }
-      }
-
-      if (that.checksum !== null) {
-        for (const error of verifyNonEmptyString(that.checksum)) {
-          error.path.prepend(new PropertySegment(that, "checksum"));
-          yield error;
         }
       }
 
@@ -3661,6 +3660,27 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       yield new VerificationError("ID-shorts of the value must be unique.");
     }
 
+    if (that.category !== null) {
+      for (const error of verifyNonEmptyString(that.category)) {
+        error.path.prepend(new PropertySegment(that, "category"));
+        yield error;
+      }
+    }
+
+    if (that.idShort !== null) {
+      for (const error of verifyIdShort(that.idShort)) {
+        error.path.prepend(new PropertySegment(that, "idShort"));
+        yield error;
+      }
+    }
+
+    if (that.checksum !== null) {
+      for (const error of verifyNonEmptyString(that.checksum)) {
+        error.path.prepend(new PropertySegment(that, "checksum"));
+        yield error;
+      }
+    }
+
     if (context === true) {
       if (that.extensions !== null) {
         let extensionsIndex = 0;
@@ -3671,20 +3691,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           extensionsIndex++;
-        }
-      }
-
-      if (that.category !== null) {
-        for (const error of verifyNonEmptyString(that.category)) {
-          error.path.prepend(new PropertySegment(that, "category"));
-          yield error;
-        }
-      }
-
-      if (that.idShort !== null) {
-        for (const error of verifyIdShort(that.idShort)) {
-          error.path.prepend(new PropertySegment(that, "idShort"));
-          yield error;
         }
       }
 
@@ -3709,13 +3715,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           descriptionIndex++;
-        }
-      }
-
-      if (that.checksum !== null) {
-        for (const error of verifyNonEmptyString(that.checksum)) {
-          error.path.prepend(new PropertySegment(that, "checksum"));
-          yield error;
         }
       }
 
@@ -3915,6 +3914,34 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       yield new VerificationError("Value must be consistent with the value type.");
     }
 
+    if (that.category !== null) {
+      for (const error of verifyNonEmptyString(that.category)) {
+        error.path.prepend(new PropertySegment(that, "category"));
+        yield error;
+      }
+    }
+
+    if (that.idShort !== null) {
+      for (const error of verifyIdShort(that.idShort)) {
+        error.path.prepend(new PropertySegment(that, "idShort"));
+        yield error;
+      }
+    }
+
+    if (that.checksum !== null) {
+      for (const error of verifyNonEmptyString(that.checksum)) {
+        error.path.prepend(new PropertySegment(that, "checksum"));
+        yield error;
+      }
+    }
+
+    if (that.value !== null) {
+      for (const error of verifyValueDataType(that.value)) {
+        error.path.prepend(new PropertySegment(that, "value"));
+        yield error;
+      }
+    }
+
     if (context === true) {
       if (that.extensions !== null) {
         let extensionsIndex = 0;
@@ -3925,20 +3952,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           extensionsIndex++;
-        }
-      }
-
-      if (that.category !== null) {
-        for (const error of verifyNonEmptyString(that.category)) {
-          error.path.prepend(new PropertySegment(that, "category"));
-          yield error;
-        }
-      }
-
-      if (that.idShort !== null) {
-        for (const error of verifyIdShort(that.idShort)) {
-          error.path.prepend(new PropertySegment(that, "idShort"));
-          yield error;
         }
       }
 
@@ -3963,13 +3976,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           descriptionIndex++;
-        }
-      }
-
-      if (that.checksum !== null) {
-        for (const error of verifyNonEmptyString(that.checksum)) {
-          error.path.prepend(new PropertySegment(that, "checksum"));
-          yield error;
         }
       }
 
@@ -4023,13 +4029,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           embeddedDataSpecificationsIndex++;
-        }
-      }
-
-      if (that.value !== null) {
-        for (const error of verifyValueDataType(that.value)) {
-          error.path.prepend(new PropertySegment(that, "value"));
-          yield error;
         }
       }
 
@@ -4173,6 +4172,27 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    if (that.category !== null) {
+      for (const error of verifyNonEmptyString(that.category)) {
+        error.path.prepend(new PropertySegment(that, "category"));
+        yield error;
+      }
+    }
+
+    if (that.idShort !== null) {
+      for (const error of verifyIdShort(that.idShort)) {
+        error.path.prepend(new PropertySegment(that, "idShort"));
+        yield error;
+      }
+    }
+
+    if (that.checksum !== null) {
+      for (const error of verifyNonEmptyString(that.checksum)) {
+        error.path.prepend(new PropertySegment(that, "checksum"));
+        yield error;
+      }
+    }
+
     if (context === true) {
       if (that.extensions !== null) {
         let extensionsIndex = 0;
@@ -4183,20 +4203,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           extensionsIndex++;
-        }
-      }
-
-      if (that.category !== null) {
-        for (const error of verifyNonEmptyString(that.category)) {
-          error.path.prepend(new PropertySegment(that, "category"));
-          yield error;
-        }
-      }
-
-      if (that.idShort !== null) {
-        for (const error of verifyIdShort(that.idShort)) {
-          error.path.prepend(new PropertySegment(that, "idShort"));
-          yield error;
         }
       }
 
@@ -4221,13 +4227,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           descriptionIndex++;
-        }
-      }
-
-      if (that.checksum !== null) {
-        for (const error of verifyNonEmptyString(that.checksum)) {
-          error.path.prepend(new PropertySegment(that, "checksum"));
-          yield error;
         }
       }
 
@@ -4438,6 +4437,41 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       yield new VerificationError("Min must be consistent with the value type.");
     }
 
+    if (that.category !== null) {
+      for (const error of verifyNonEmptyString(that.category)) {
+        error.path.prepend(new PropertySegment(that, "category"));
+        yield error;
+      }
+    }
+
+    if (that.idShort !== null) {
+      for (const error of verifyIdShort(that.idShort)) {
+        error.path.prepend(new PropertySegment(that, "idShort"));
+        yield error;
+      }
+    }
+
+    if (that.checksum !== null) {
+      for (const error of verifyNonEmptyString(that.checksum)) {
+        error.path.prepend(new PropertySegment(that, "checksum"));
+        yield error;
+      }
+    }
+
+    if (that.min !== null) {
+      for (const error of verifyValueDataType(that.min)) {
+        error.path.prepend(new PropertySegment(that, "min"));
+        yield error;
+      }
+    }
+
+    if (that.max !== null) {
+      for (const error of verifyValueDataType(that.max)) {
+        error.path.prepend(new PropertySegment(that, "max"));
+        yield error;
+      }
+    }
+
     if (context === true) {
       if (that.extensions !== null) {
         let extensionsIndex = 0;
@@ -4448,20 +4482,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           extensionsIndex++;
-        }
-      }
-
-      if (that.category !== null) {
-        for (const error of verifyNonEmptyString(that.category)) {
-          error.path.prepend(new PropertySegment(that, "category"));
-          yield error;
-        }
-      }
-
-      if (that.idShort !== null) {
-        for (const error of verifyIdShort(that.idShort)) {
-          error.path.prepend(new PropertySegment(that, "idShort"));
-          yield error;
         }
       }
 
@@ -4486,13 +4506,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           descriptionIndex++;
-        }
-      }
-
-      if (that.checksum !== null) {
-        for (const error of verifyNonEmptyString(that.checksum)) {
-          error.path.prepend(new PropertySegment(that, "checksum"));
-          yield error;
         }
       }
 
@@ -4546,20 +4559,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           embeddedDataSpecificationsIndex++;
-        }
-      }
-
-      if (that.min !== null) {
-        for (const error of verifyValueDataType(that.min)) {
-          error.path.prepend(new PropertySegment(that, "min"));
-          yield error;
-        }
-      }
-
-      if (that.max !== null) {
-        for (const error of verifyValueDataType(that.max)) {
-          error.path.prepend(new PropertySegment(that, "max"));
-          yield error;
         }
       }
     }
@@ -4686,6 +4685,27 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    if (that.category !== null) {
+      for (const error of verifyNonEmptyString(that.category)) {
+        error.path.prepend(new PropertySegment(that, "category"));
+        yield error;
+      }
+    }
+
+    if (that.idShort !== null) {
+      for (const error of verifyIdShort(that.idShort)) {
+        error.path.prepend(new PropertySegment(that, "idShort"));
+        yield error;
+      }
+    }
+
+    if (that.checksum !== null) {
+      for (const error of verifyNonEmptyString(that.checksum)) {
+        error.path.prepend(new PropertySegment(that, "checksum"));
+        yield error;
+      }
+    }
+
     if (context === true) {
       if (that.extensions !== null) {
         let extensionsIndex = 0;
@@ -4696,20 +4716,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           extensionsIndex++;
-        }
-      }
-
-      if (that.category !== null) {
-        for (const error of verifyNonEmptyString(that.category)) {
-          error.path.prepend(new PropertySegment(that, "category"));
-          yield error;
-        }
-      }
-
-      if (that.idShort !== null) {
-        for (const error of verifyIdShort(that.idShort)) {
-          error.path.prepend(new PropertySegment(that, "idShort"));
-          yield error;
         }
       }
 
@@ -4734,13 +4740,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           descriptionIndex++;
-        }
-      }
-
-      if (that.checksum !== null) {
-        for (const error of verifyNonEmptyString(that.checksum)) {
-          error.path.prepend(new PropertySegment(that, "checksum"));
-          yield error;
         }
       }
 
@@ -4927,6 +4926,39 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    if (that.category !== null) {
+      for (const error of verifyNonEmptyString(that.category)) {
+        error.path.prepend(new PropertySegment(that, "category"));
+        yield error;
+      }
+    }
+
+    if (that.idShort !== null) {
+      for (const error of verifyIdShort(that.idShort)) {
+        error.path.prepend(new PropertySegment(that, "idShort"));
+        yield error;
+      }
+    }
+
+    if (that.checksum !== null) {
+      for (const error of verifyNonEmptyString(that.checksum)) {
+        error.path.prepend(new PropertySegment(that, "checksum"));
+        yield error;
+      }
+    }
+
+    if (that.value !== null) {
+      for (const error of verifyBlobType(that.value)) {
+        error.path.prepend(new PropertySegment(that, "value"));
+        yield error;
+      }
+    }
+
+    for (const error of verifyContentType(that.contentType)) {
+      error.path.prepend(new PropertySegment(that, "contentType"));
+      yield error;
+    }
+
     if (context === true) {
       if (that.extensions !== null) {
         let extensionsIndex = 0;
@@ -4937,20 +4969,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           extensionsIndex++;
-        }
-      }
-
-      if (that.category !== null) {
-        for (const error of verifyNonEmptyString(that.category)) {
-          error.path.prepend(new PropertySegment(that, "category"));
-          yield error;
-        }
-      }
-
-      if (that.idShort !== null) {
-        for (const error of verifyIdShort(that.idShort)) {
-          error.path.prepend(new PropertySegment(that, "idShort"));
-          yield error;
         }
       }
 
@@ -4975,13 +4993,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           descriptionIndex++;
-        }
-      }
-
-      if (that.checksum !== null) {
-        for (const error of verifyNonEmptyString(that.checksum)) {
-          error.path.prepend(new PropertySegment(that, "checksum"));
-          yield error;
         }
       }
 
@@ -5036,18 +5047,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
           }
           embeddedDataSpecificationsIndex++;
         }
-      }
-
-      if (that.value !== null) {
-        for (const error of verifyBlobType(that.value)) {
-          error.path.prepend(new PropertySegment(that, "value"));
-          yield error;
-        }
-      }
-
-      for (const error of verifyContentType(that.contentType)) {
-        error.path.prepend(new PropertySegment(that, "contentType"));
-        yield error;
       }
     }
   }
@@ -5173,6 +5172,39 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    if (that.category !== null) {
+      for (const error of verifyNonEmptyString(that.category)) {
+        error.path.prepend(new PropertySegment(that, "category"));
+        yield error;
+      }
+    }
+
+    if (that.idShort !== null) {
+      for (const error of verifyIdShort(that.idShort)) {
+        error.path.prepend(new PropertySegment(that, "idShort"));
+        yield error;
+      }
+    }
+
+    if (that.checksum !== null) {
+      for (const error of verifyNonEmptyString(that.checksum)) {
+        error.path.prepend(new PropertySegment(that, "checksum"));
+        yield error;
+      }
+    }
+
+    if (that.value !== null) {
+      for (const error of verifyPathType(that.value)) {
+        error.path.prepend(new PropertySegment(that, "value"));
+        yield error;
+      }
+    }
+
+    for (const error of verifyContentType(that.contentType)) {
+      error.path.prepend(new PropertySegment(that, "contentType"));
+      yield error;
+    }
+
     if (context === true) {
       if (that.extensions !== null) {
         let extensionsIndex = 0;
@@ -5183,20 +5215,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           extensionsIndex++;
-        }
-      }
-
-      if (that.category !== null) {
-        for (const error of verifyNonEmptyString(that.category)) {
-          error.path.prepend(new PropertySegment(that, "category"));
-          yield error;
-        }
-      }
-
-      if (that.idShort !== null) {
-        for (const error of verifyIdShort(that.idShort)) {
-          error.path.prepend(new PropertySegment(that, "idShort"));
-          yield error;
         }
       }
 
@@ -5221,13 +5239,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           descriptionIndex++;
-        }
-      }
-
-      if (that.checksum !== null) {
-        for (const error of verifyNonEmptyString(that.checksum)) {
-          error.path.prepend(new PropertySegment(that, "checksum"));
-          yield error;
         }
       }
 
@@ -5282,18 +5293,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
           }
           embeddedDataSpecificationsIndex++;
         }
-      }
-
-      if (that.value !== null) {
-        for (const error of verifyPathType(that.value)) {
-          error.path.prepend(new PropertySegment(that, "value"));
-          yield error;
-        }
-      }
-
-      for (const error of verifyContentType(that.contentType)) {
-        error.path.prepend(new PropertySegment(that, "contentType"));
-        yield error;
       }
     }
   }
@@ -5413,6 +5412,27 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    if (that.category !== null) {
+      for (const error of verifyNonEmptyString(that.category)) {
+        error.path.prepend(new PropertySegment(that, "category"));
+        yield error;
+      }
+    }
+
+    if (that.idShort !== null) {
+      for (const error of verifyIdShort(that.idShort)) {
+        error.path.prepend(new PropertySegment(that, "idShort"));
+        yield error;
+      }
+    }
+
+    if (that.checksum !== null) {
+      for (const error of verifyNonEmptyString(that.checksum)) {
+        error.path.prepend(new PropertySegment(that, "checksum"));
+        yield error;
+      }
+    }
+
     if (context === true) {
       if (that.extensions !== null) {
         let extensionsIndex = 0;
@@ -5423,20 +5443,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           extensionsIndex++;
-        }
-      }
-
-      if (that.category !== null) {
-        for (const error of verifyNonEmptyString(that.category)) {
-          error.path.prepend(new PropertySegment(that, "category"));
-          yield error;
-        }
-      }
-
-      if (that.idShort !== null) {
-        for (const error of verifyIdShort(that.idShort)) {
-          error.path.prepend(new PropertySegment(that, "idShort"));
-          yield error;
         }
       }
 
@@ -5461,13 +5467,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           descriptionIndex++;
-        }
-      }
-
-      if (that.checksum !== null) {
-        for (const error of verifyNonEmptyString(that.checksum)) {
-          error.path.prepend(new PropertySegment(that, "checksum"));
-          yield error;
         }
       }
 
@@ -5678,6 +5677,27 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    if (that.category !== null) {
+      for (const error of verifyNonEmptyString(that.category)) {
+        error.path.prepend(new PropertySegment(that, "category"));
+        yield error;
+      }
+    }
+
+    if (that.idShort !== null) {
+      for (const error of verifyIdShort(that.idShort)) {
+        error.path.prepend(new PropertySegment(that, "idShort"));
+        yield error;
+      }
+    }
+
+    if (that.checksum !== null) {
+      for (const error of verifyNonEmptyString(that.checksum)) {
+        error.path.prepend(new PropertySegment(that, "checksum"));
+        yield error;
+      }
+    }
+
     if (context === true) {
       if (that.extensions !== null) {
         let extensionsIndex = 0;
@@ -5688,20 +5708,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           extensionsIndex++;
-        }
-      }
-
-      if (that.category !== null) {
-        for (const error of verifyNonEmptyString(that.category)) {
-          error.path.prepend(new PropertySegment(that, "category"));
-          yield error;
-        }
-      }
-
-      if (that.idShort !== null) {
-        for (const error of verifyIdShort(that.idShort)) {
-          error.path.prepend(new PropertySegment(that, "idShort"));
-          yield error;
         }
       }
 
@@ -5726,13 +5732,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           descriptionIndex++;
-        }
-      }
-
-      if (that.checksum !== null) {
-        for (const error of verifyNonEmptyString(that.checksum)) {
-          error.path.prepend(new PropertySegment(that, "checksum"));
-          yield error;
         }
       }
 
@@ -5831,6 +5830,25 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    if (that.topic !== null) {
+      for (const error of verifyNonEmptyString(that.topic)) {
+        error.path.prepend(new PropertySegment(that, "topic"));
+        yield error;
+      }
+    }
+
+    for (const error of verifyDateTimeStampUtc(that.timeStamp)) {
+      error.path.prepend(new PropertySegment(that, "timeStamp"));
+      yield error;
+    }
+
+    if (that.payload !== null) {
+      for (const error of verifyNonEmptyString(that.payload)) {
+        error.path.prepend(new PropertySegment(that, "payload"));
+        yield error;
+      }
+    }
+
     if (context === true) {
       for (const error of this.transformWithContext(that.source, context)) {
         error.path.prepend(new PropertySegment(that, "source"));
@@ -5862,28 +5880,9 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
         }
       }
 
-      if (that.topic !== null) {
-        for (const error of verifyNonEmptyString(that.topic)) {
-          error.path.prepend(new PropertySegment(that, "topic"));
-          yield error;
-        }
-      }
-
       if (that.subjectId !== null) {
         for (const error of this.transformWithContext(that.subjectId, context)) {
           error.path.prepend(new PropertySegment(that, "subjectId"));
-          yield error;
-        }
-      }
-
-      for (const error of verifyDateTimeStampUtc(that.timeStamp)) {
-        error.path.prepend(new PropertySegment(that, "timeStamp"));
-        yield error;
-      }
-
-      if (that.payload !== null) {
-        for (const error of verifyNonEmptyString(that.payload)) {
-          error.path.prepend(new PropertySegment(that, "payload"));
           yield error;
         }
       }
@@ -6020,6 +6019,55 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    if (that.category !== null) {
+      for (const error of verifyNonEmptyString(that.category)) {
+        error.path.prepend(new PropertySegment(that, "category"));
+        yield error;
+      }
+    }
+
+    if (that.idShort !== null) {
+      for (const error of verifyIdShort(that.idShort)) {
+        error.path.prepend(new PropertySegment(that, "idShort"));
+        yield error;
+      }
+    }
+
+    if (that.checksum !== null) {
+      for (const error of verifyNonEmptyString(that.checksum)) {
+        error.path.prepend(new PropertySegment(that, "checksum"));
+        yield error;
+      }
+    }
+
+    if (that.messageTopic !== null) {
+      for (const error of verifyNonEmptyString(that.messageTopic)) {
+        error.path.prepend(new PropertySegment(that, "messageTopic"));
+        yield error;
+      }
+    }
+
+    if (that.lastUpdate !== null) {
+      for (const error of verifyDateTimeStampUtc(that.lastUpdate)) {
+        error.path.prepend(new PropertySegment(that, "lastUpdate"));
+        yield error;
+      }
+    }
+
+    if (that.minInterval !== null) {
+      for (const error of verifyDateTimeStampUtc(that.minInterval)) {
+        error.path.prepend(new PropertySegment(that, "minInterval"));
+        yield error;
+      }
+    }
+
+    if (that.maxInterval !== null) {
+      for (const error of verifyDateTimeStampUtc(that.maxInterval)) {
+        error.path.prepend(new PropertySegment(that, "maxInterval"));
+        yield error;
+      }
+    }
+
     if (context === true) {
       if (that.extensions !== null) {
         let extensionsIndex = 0;
@@ -6030,20 +6078,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           extensionsIndex++;
-        }
-      }
-
-      if (that.category !== null) {
-        for (const error of verifyNonEmptyString(that.category)) {
-          error.path.prepend(new PropertySegment(that, "category"));
-          yield error;
-        }
-      }
-
-      if (that.idShort !== null) {
-        for (const error of verifyIdShort(that.idShort)) {
-          error.path.prepend(new PropertySegment(that, "idShort"));
-          yield error;
         }
       }
 
@@ -6068,13 +6102,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           descriptionIndex++;
-        }
-      }
-
-      if (that.checksum !== null) {
-        for (const error of verifyNonEmptyString(that.checksum)) {
-          error.path.prepend(new PropertySegment(that, "checksum"));
-          yield error;
         }
       }
 
@@ -6136,37 +6163,9 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
         yield error;
       }
 
-      if (that.messageTopic !== null) {
-        for (const error of verifyNonEmptyString(that.messageTopic)) {
-          error.path.prepend(new PropertySegment(that, "messageTopic"));
-          yield error;
-        }
-      }
-
       if (that.messageBroker !== null) {
         for (const error of this.transformWithContext(that.messageBroker, context)) {
           error.path.prepend(new PropertySegment(that, "messageBroker"));
-          yield error;
-        }
-      }
-
-      if (that.lastUpdate !== null) {
-        for (const error of verifyDateTimeStampUtc(that.lastUpdate)) {
-          error.path.prepend(new PropertySegment(that, "lastUpdate"));
-          yield error;
-        }
-      }
-
-      if (that.minInterval !== null) {
-        for (const error of verifyDateTimeStampUtc(that.minInterval)) {
-          error.path.prepend(new PropertySegment(that, "minInterval"));
-          yield error;
-        }
-      }
-
-      if (that.maxInterval !== null) {
-        for (const error of verifyDateTimeStampUtc(that.maxInterval)) {
-          error.path.prepend(new PropertySegment(that, "maxInterval"));
           yield error;
         }
       }
@@ -6300,6 +6299,27 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    if (that.category !== null) {
+      for (const error of verifyNonEmptyString(that.category)) {
+        error.path.prepend(new PropertySegment(that, "category"));
+        yield error;
+      }
+    }
+
+    if (that.idShort !== null) {
+      for (const error of verifyIdShort(that.idShort)) {
+        error.path.prepend(new PropertySegment(that, "idShort"));
+        yield error;
+      }
+    }
+
+    if (that.checksum !== null) {
+      for (const error of verifyNonEmptyString(that.checksum)) {
+        error.path.prepend(new PropertySegment(that, "checksum"));
+        yield error;
+      }
+    }
+
     if (context === true) {
       if (that.extensions !== null) {
         let extensionsIndex = 0;
@@ -6310,20 +6330,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           extensionsIndex++;
-        }
-      }
-
-      if (that.category !== null) {
-        for (const error of verifyNonEmptyString(that.category)) {
-          error.path.prepend(new PropertySegment(that, "category"));
-          yield error;
-        }
-      }
-
-      if (that.idShort !== null) {
-        for (const error of verifyIdShort(that.idShort)) {
-          error.path.prepend(new PropertySegment(that, "idShort"));
-          yield error;
         }
       }
 
@@ -6348,13 +6354,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           descriptionIndex++;
-        }
-      }
-
-      if (that.checksum !== null) {
-        for (const error of verifyNonEmptyString(that.checksum)) {
-          error.path.prepend(new PropertySegment(that, "checksum"));
-          yield error;
         }
       }
 
@@ -6576,6 +6575,27 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    if (that.category !== null) {
+      for (const error of verifyNonEmptyString(that.category)) {
+        error.path.prepend(new PropertySegment(that, "category"));
+        yield error;
+      }
+    }
+
+    if (that.idShort !== null) {
+      for (const error of verifyIdShort(that.idShort)) {
+        error.path.prepend(new PropertySegment(that, "idShort"));
+        yield error;
+      }
+    }
+
+    if (that.checksum !== null) {
+      for (const error of verifyNonEmptyString(that.checksum)) {
+        error.path.prepend(new PropertySegment(that, "checksum"));
+        yield error;
+      }
+    }
+
     if (context === true) {
       if (that.extensions !== null) {
         let extensionsIndex = 0;
@@ -6586,20 +6606,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           extensionsIndex++;
-        }
-      }
-
-      if (that.category !== null) {
-        for (const error of verifyNonEmptyString(that.category)) {
-          error.path.prepend(new PropertySegment(that, "category"));
-          yield error;
-        }
-      }
-
-      if (that.idShort !== null) {
-        for (const error of verifyIdShort(that.idShort)) {
-          error.path.prepend(new PropertySegment(that, "idShort"));
-          yield error;
         }
       }
 
@@ -6624,13 +6630,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           descriptionIndex++;
-        }
-      }
-
-      if (that.checksum !== null) {
-        for (const error of verifyNonEmptyString(that.checksum)) {
-          error.path.prepend(new PropertySegment(that, "checksum"));
-          yield error;
         }
       }
 
@@ -6883,6 +6882,32 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    if (that.category !== null) {
+      for (const error of verifyNonEmptyString(that.category)) {
+        error.path.prepend(new PropertySegment(that, "category"));
+        yield error;
+      }
+    }
+
+    if (that.idShort !== null) {
+      for (const error of verifyIdShort(that.idShort)) {
+        error.path.prepend(new PropertySegment(that, "idShort"));
+        yield error;
+      }
+    }
+
+    if (that.checksum !== null) {
+      for (const error of verifyNonEmptyString(that.checksum)) {
+        error.path.prepend(new PropertySegment(that, "checksum"));
+        yield error;
+      }
+    }
+
+    for (const error of verifyIdentifier(that.id)) {
+      error.path.prepend(new PropertySegment(that, "id"));
+      yield error;
+    }
+
     if (context === true) {
       if (that.extensions !== null) {
         let extensionsIndex = 0;
@@ -6893,20 +6918,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           extensionsIndex++;
-        }
-      }
-
-      if (that.category !== null) {
-        for (const error of verifyNonEmptyString(that.category)) {
-          error.path.prepend(new PropertySegment(that, "category"));
-          yield error;
-        }
-      }
-
-      if (that.idShort !== null) {
-        for (const error of verifyIdShort(that.idShort)) {
-          error.path.prepend(new PropertySegment(that, "idShort"));
-          yield error;
         }
       }
 
@@ -6934,23 +6945,11 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
         }
       }
 
-      if (that.checksum !== null) {
-        for (const error of verifyNonEmptyString(that.checksum)) {
-          error.path.prepend(new PropertySegment(that, "checksum"));
-          yield error;
-        }
-      }
-
       if (that.administration !== null) {
         for (const error of this.transformWithContext(that.administration, context)) {
           error.path.prepend(new PropertySegment(that, "administration"));
           yield error;
         }
-      }
-
-      for (const error of verifyIdentifier(that.id)) {
-        error.path.prepend(new PropertySegment(that, "id"));
-        yield error;
       }
 
       if (that.embeddedDataSpecifications !== null) {
@@ -7158,25 +7157,23 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
 
   *transformKeyWithContext(
     that: AasTypes.Key,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     context: boolean
   ): IterableIterator<VerificationError> {
-    if (context === true) {
-      for (const error of verifyNonEmptyString(that.value)) {
-        error.path.prepend(new PropertySegment(that, "value"));
-        yield error;
-      }
+    for (const error of verifyNonEmptyString(that.value)) {
+      error.path.prepend(new PropertySegment(that, "value"));
+      yield error;
     }
   }
 
   *transformLangStringWithContext(
     that: AasTypes.LangString,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     context: boolean
   ): IterableIterator<VerificationError> {
-    if (context === true) {
-      for (const error of verifyBcp47LanguageTag(that.language)) {
-        error.path.prepend(new PropertySegment(that, "language"));
-        yield error;
-      }
+    for (const error of verifyBcp47LanguageTag(that.language)) {
+      error.path.prepend(new PropertySegment(that, "language"));
+      yield error;
     }
   }
 
@@ -7393,6 +7390,34 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       );
     }
 
+    if (that.unit !== null) {
+      for (const error of verifyNonEmptyString(that.unit)) {
+        error.path.prepend(new PropertySegment(that, "unit"));
+        yield error;
+      }
+    }
+
+    if (that.sourceOfDefinition !== null) {
+      for (const error of verifyNonEmptyString(that.sourceOfDefinition)) {
+        error.path.prepend(new PropertySegment(that, "sourceOfDefinition"));
+        yield error;
+      }
+    }
+
+    if (that.symbol !== null) {
+      for (const error of verifyNonEmptyString(that.symbol)) {
+        error.path.prepend(new PropertySegment(that, "symbol"));
+        yield error;
+      }
+    }
+
+    if (that.valueFormat !== null) {
+      for (const error of verifyNonEmptyString(that.valueFormat)) {
+        error.path.prepend(new PropertySegment(that, "valueFormat"));
+        yield error;
+      }
+    }
+
     if (context === true) {
       let preferredNameIndex = 0;
       for (const item of that.preferredName) {
@@ -7416,30 +7441,9 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
         }
       }
 
-      if (that.unit !== null) {
-        for (const error of verifyNonEmptyString(that.unit)) {
-          error.path.prepend(new PropertySegment(that, "unit"));
-          yield error;
-        }
-      }
-
       if (that.unitId !== null) {
         for (const error of this.transformWithContext(that.unitId, context)) {
           error.path.prepend(new PropertySegment(that, "unitId"));
-          yield error;
-        }
-      }
-
-      if (that.sourceOfDefinition !== null) {
-        for (const error of verifyNonEmptyString(that.sourceOfDefinition)) {
-          error.path.prepend(new PropertySegment(that, "sourceOfDefinition"));
-          yield error;
-        }
-      }
-
-      if (that.symbol !== null) {
-        for (const error of verifyNonEmptyString(that.symbol)) {
-          error.path.prepend(new PropertySegment(that, "symbol"));
           yield error;
         }
       }
@@ -7453,13 +7457,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             yield error;
           }
           definitionIndex++;
-        }
-      }
-
-      if (that.valueFormat !== null) {
-        for (const error of verifyNonEmptyString(that.valueFormat)) {
-          error.path.prepend(new PropertySegment(that, "valueFormat"));
-          yield error;
         }
       }
 
@@ -7484,17 +7481,87 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
       yield new VerificationError("Definition specifies no duplicate languages");
     }
 
+    for (const error of verifyNonEmptyString(that.unitName)) {
+      error.path.prepend(new PropertySegment(that, "unitName"));
+      yield error;
+    }
+
+    for (const error of verifyNonEmptyString(that.unitSymbol)) {
+      error.path.prepend(new PropertySegment(that, "unitSymbol"));
+      yield error;
+    }
+
+    if (that.siNotation !== null) {
+      for (const error of verifyNonEmptyString(that.siNotation)) {
+        error.path.prepend(new PropertySegment(that, "siNotation"));
+        yield error;
+      }
+    }
+
+    if (that.siName !== null) {
+      for (const error of verifyNonEmptyString(that.siName)) {
+        error.path.prepend(new PropertySegment(that, "siName"));
+        yield error;
+      }
+    }
+
+    if (that.dinNotation !== null) {
+      for (const error of verifyNonEmptyString(that.dinNotation)) {
+        error.path.prepend(new PropertySegment(that, "dinNotation"));
+        yield error;
+      }
+    }
+
+    if (that.eceName !== null) {
+      for (const error of verifyNonEmptyString(that.eceName)) {
+        error.path.prepend(new PropertySegment(that, "eceName"));
+        yield error;
+      }
+    }
+
+    if (that.eceCode !== null) {
+      for (const error of verifyNonEmptyString(that.eceCode)) {
+        error.path.prepend(new PropertySegment(that, "eceCode"));
+        yield error;
+      }
+    }
+
+    if (that.nistName !== null) {
+      for (const error of verifyNonEmptyString(that.nistName)) {
+        error.path.prepend(new PropertySegment(that, "nistName"));
+        yield error;
+      }
+    }
+
+    if (that.sourceOfDefinition !== null) {
+      for (const error of verifyNonEmptyString(that.sourceOfDefinition)) {
+        error.path.prepend(new PropertySegment(that, "sourceOfDefinition"));
+        yield error;
+      }
+    }
+
+    if (that.conversionFactor !== null) {
+      for (const error of verifyNonEmptyString(that.conversionFactor)) {
+        error.path.prepend(new PropertySegment(that, "conversionFactor"));
+        yield error;
+      }
+    }
+
+    if (that.registrationAuthorityId !== null) {
+      for (const error of verifyNonEmptyString(that.registrationAuthorityId)) {
+        error.path.prepend(new PropertySegment(that, "registrationAuthorityId"));
+        yield error;
+      }
+    }
+
+    if (that.supplier !== null) {
+      for (const error of verifyNonEmptyString(that.supplier)) {
+        error.path.prepend(new PropertySegment(that, "supplier"));
+        yield error;
+      }
+    }
+
     if (context === true) {
-      for (const error of verifyNonEmptyString(that.unitName)) {
-        error.path.prepend(new PropertySegment(that, "unitName"));
-        yield error;
-      }
-
-      for (const error of verifyNonEmptyString(that.unitSymbol)) {
-        error.path.prepend(new PropertySegment(that, "unitSymbol"));
-        yield error;
-      }
-
       let definitionIndex = 0;
       for (const item of that.definition) {
         for (const error of this.transformWithContext(item, context)) {
@@ -7503,76 +7570,6 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
           yield error;
         }
         definitionIndex++;
-      }
-
-      if (that.siNotation !== null) {
-        for (const error of verifyNonEmptyString(that.siNotation)) {
-          error.path.prepend(new PropertySegment(that, "siNotation"));
-          yield error;
-        }
-      }
-
-      if (that.siName !== null) {
-        for (const error of verifyNonEmptyString(that.siName)) {
-          error.path.prepend(new PropertySegment(that, "siName"));
-          yield error;
-        }
-      }
-
-      if (that.dinNotation !== null) {
-        for (const error of verifyNonEmptyString(that.dinNotation)) {
-          error.path.prepend(new PropertySegment(that, "dinNotation"));
-          yield error;
-        }
-      }
-
-      if (that.eceName !== null) {
-        for (const error of verifyNonEmptyString(that.eceName)) {
-          error.path.prepend(new PropertySegment(that, "eceName"));
-          yield error;
-        }
-      }
-
-      if (that.eceCode !== null) {
-        for (const error of verifyNonEmptyString(that.eceCode)) {
-          error.path.prepend(new PropertySegment(that, "eceCode"));
-          yield error;
-        }
-      }
-
-      if (that.nistName !== null) {
-        for (const error of verifyNonEmptyString(that.nistName)) {
-          error.path.prepend(new PropertySegment(that, "nistName"));
-          yield error;
-        }
-      }
-
-      if (that.sourceOfDefinition !== null) {
-        for (const error of verifyNonEmptyString(that.sourceOfDefinition)) {
-          error.path.prepend(new PropertySegment(that, "sourceOfDefinition"));
-          yield error;
-        }
-      }
-
-      if (that.conversionFactor !== null) {
-        for (const error of verifyNonEmptyString(that.conversionFactor)) {
-          error.path.prepend(new PropertySegment(that, "conversionFactor"));
-          yield error;
-        }
-      }
-
-      if (that.registrationAuthorityId !== null) {
-        for (const error of verifyNonEmptyString(that.registrationAuthorityId)) {
-          error.path.prepend(new PropertySegment(that, "registrationAuthorityId"));
-          yield error;
-        }
-      }
-
-      if (that.supplier !== null) {
-        for (const error of verifyNonEmptyString(that.supplier)) {
-          error.path.prepend(new PropertySegment(that, "supplier"));
-          yield error;
-        }
       }
     }
   }


### PR DESCRIPTION
We grouped properties of constrained primitives with all the other properties in the recusrion block. This is obviously wrong, as we want to verify the constrained primitives regardless of the recursion in the verification context.

This patch fixes the issue.

Generated with:
* [aas-core-codegen 69570c0]

[aas-core-codegen 69570c0]: https://github.com/aas-core-works/aas-core-codegen/commit/69570c0