### PR TITLE
Fix detection of arrays instead of objects

### DIFF
--- a/src/jsonization.ts
+++ b/src/jsonization.ts
@@ -297,6 +297,11 @@ export function hasSemanticsFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.IHasSemantics>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.IHasSemantics>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -497,6 +502,11 @@ export function extensionFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.Extension>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.Extension>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -561,6 +571,11 @@ export function hasExtensionsFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.IHasExtensions>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.IHasExtensions>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -605,6 +620,11 @@ export function referableFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.IReferable>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.IReferable>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -647,6 +667,11 @@ export function identifiableFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.IIdentifiable>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.IIdentifiable>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -722,6 +747,11 @@ export function hasKindFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.IHasKind>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.IHasKind>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -764,6 +794,11 @@ export function hasDataSpecificationFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.IHasDataSpecification>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.IHasDataSpecification>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -912,6 +947,11 @@ export function administrativeInformationFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.AdministrativeInformation>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.AdministrativeInformation>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -965,6 +1005,11 @@ export function qualifiableFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.IQualifiable>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.IQualifiable>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -1213,6 +1258,11 @@ export function qualifierFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.Qualifier>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.Qualifier>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -1658,6 +1708,11 @@ export function assetAdministrationShellFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.AssetAdministrationShell>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.AssetAdministrationShell>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -1852,6 +1907,11 @@ export function assetInformationFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.AssetInformation>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.AssetInformation>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -1967,6 +2027,11 @@ export function resourceFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.Resource>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.Resource>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -2185,6 +2250,11 @@ export function specificAssetIdFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.SpecificAssetId>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.SpecificAssetId>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -2726,6 +2796,11 @@ export function submodelFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.Submodel>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.Submodel>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -2795,6 +2870,11 @@ export function submodelElementFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.ISubmodelElement>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.ISubmodelElement>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -2837,6 +2917,11 @@ export function relationshipElementFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.IRelationshipElement>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.IRelationshipElement>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -3307,6 +3392,11 @@ function relationshipElementFromJsonableWithoutDispatch(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.RelationshipElement>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.RelationshipElement>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -3922,6 +4012,11 @@ export function submodelElementListFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.SubmodelElementList>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.SubmodelElementList>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -4424,6 +4519,11 @@ export function submodelElementCollectionFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.SubmodelElementCollection>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.SubmodelElementCollection>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -4486,6 +4586,11 @@ export function dataElementFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.IDataElement>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.IDataElement>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -4967,6 +5072,11 @@ export function propertyFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.Property>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.Property>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -5484,6 +5594,11 @@ export function multiLanguagePropertyFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.MultiLanguageProperty>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.MultiLanguageProperty>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -5986,6 +6101,11 @@ export function rangeFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.Range>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.Range>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -6454,6 +6574,11 @@ export function referenceElementFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.ReferenceElement>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.ReferenceElement>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -6937,6 +7062,11 @@ export function blobFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.Blob>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.Blob>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -7424,6 +7554,11 @@ export function fileFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.File>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.File>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -7956,6 +8091,11 @@ export function annotatedRelationshipElementFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.AnnotatedRelationshipElement>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.AnnotatedRelationshipElement>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -8547,6 +8687,11 @@ export function entityFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.Entity>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.Entity>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -8837,6 +8982,11 @@ export function eventPayloadFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.EventPayload>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.EventPayload>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -8913,6 +9063,11 @@ export function eventElementFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.IEventElement>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.IEventElement>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -9484,6 +9639,11 @@ export function basicEventElementFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.BasicEventElement>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.BasicEventElement>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -10093,6 +10253,11 @@ export function operationFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.Operation>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.Operation>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -10194,6 +10359,11 @@ export function operationVariableFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.OperationVariable>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.OperationVariable>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -10636,6 +10806,11 @@ export function capabilityFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.Capability>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.Capability>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -11035,6 +11210,11 @@ export function conceptDescriptionFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.ConceptDescription>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.ConceptDescription>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -11233,6 +11413,11 @@ export function referenceFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.Reference>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.Reference>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -11349,6 +11534,11 @@ export function keyFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.Key>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.Key>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -11520,6 +11710,11 @@ export function langStringFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.LangString>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.LangString>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -11741,6 +11936,11 @@ export function environmentFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.Environment>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.Environment>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -11794,6 +11994,11 @@ export function dataSpecificationContentFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.IDataSpecificationContent>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.IDataSpecificationContent>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -11895,6 +12100,11 @@ export function embeddedDataSpecificationFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.EmbeddedDataSpecification>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.EmbeddedDataSpecification>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -12074,6 +12284,11 @@ export function valueReferencePairFromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.ValueReferencePair>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.ValueReferencePair>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -12199,6 +12414,11 @@ export function valueListFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.ValueList>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.ValueList>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {
@@ -12574,6 +12794,11 @@ export function dataSpecificationIec61360FromJsonable(
       "Expected a JSON object, but got null"
     );
   }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.DataSpecificationIec61360>(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
   if (typeof jsonable !== "object") {
     return newDeserializationError<AasTypes.DataSpecificationIec61360>(
       `Expected a JSON object, but got: ${typeof jsonable}`
@@ -12924,6 +13149,11 @@ export function dataSpecificationPhysicalUnitFromJsonable(
   if (jsonable === null) {
     return newDeserializationError<AasTypes.DataSpecificationPhysicalUnit>(
       "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return newDeserializationError<AasTypes.DataSpecificationPhysicalUnit>(
+      "Expected a JSON object, but got a JSON array"
     );
   }
   if (typeof jsonable !== "object") {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,20 @@
 /**
- * Provide the meta-model for Asset Administration Shell V3.0 Release Candidate 2.
+ * Provide an implementation of the Asset Administration Shell V3.0 Release Candidate 2.
  *
  * @remarks
- * We had to diverge from the book in the following points.
+ * The presented version of the Metamodel is related to the work of
+ * aas-core-works, which can be found here: https://github.com/aas-core-works.
  *
- * We could not implement the following constraints as they are too general and can not
+ * The presented content is neither related to the IDTA nor
+ * Plattform Industrie 4.0 and does not represent an official publication.
+ *
+ * We diverge from the book in the following points.
+ *
+ * We did not implement the following constraints as they are too general and can not
  * be formalized as part of the core library, but affects external components such as
  * AAS registry or AAS server:
  *
- * We could not implement the following constraints since they depend on registry and
+ * We did not implement the following constraints since they depend on registry and
  * de-referencing, so we can not formalize them with formalizing such external
  * dependencies:
  *


### PR DESCRIPTION
In JavaScript, arrays are objects. This makes our checks during the deserialization to fail for missing properties, but not for the incorrect type.

This patch introduces a proper check that the value is not an array.

Based on [aas-core-codegen 48c8204].

[aas-core-codegen 48c8204]: https://github.com/aas-core-works/aas-core-codegen/commit/48c8204